### PR TITLE
add more infos about developers landing page and tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -1194,12 +1194,13 @@
           <p>
             We don’t offer an integrated view on the tools that we make available to developers.
             There is ongoing work in exposing this through a simple landing page.
-            The <a href="http://w3c.github.io/developer-tools/">W3C developer tools page</a> aims to
+            The <a href="http://w3c.github.io/developers/">W3C developer page</a> aims to
             provide developers with a summary of all our open source tools and links to helpful
             resources. It is currently in development, you can
-            <a href="https://github.com/w3c/developer-tools">contribute to it in its Github
+            <a href="https://github.com/w3c/developers">contribute to it in its Github
             repository.</a>
           </p>
+            <p>You are very welcome to join the discussion about features, design and more into <a href="https://github.com/w3c/developers/issues">the developers repository's issue feed.</a> </p>
         </section>
         <section>
           <h2>Link Checker</h2>
@@ -1228,6 +1229,7 @@
             language more likely to be reusable by Web developers, namely JavaScript. While this may
             be true, it can only be a long-term, low-priority objective.
           </p>
+            <p>note: <a href="https://validator.nu/">Validator.nu</a> is the HTML5  checker base for the Markup validator.</p>
         </section>
         <section>
           <h2>I18N Checker</h2>
@@ -1259,6 +1261,18 @@
             <a href="https://github.com/w3c/Mobile-Checker">Mobile Checker</a>. It is expected to
             be released soon.
           </p>
+        </section>
+        <section>
+          <h2>Other Tools &amp; APIs</h2>
+          <p>
+              These tools and APIs are currently not the top priority concerning the developers landing page but will be consider as soon as possible.
+          </p>
+            <ul>
+                <li><a href="http://www.w3.org/RDF/Validator/">RDF Validator</a></li>
+                <li><a href="http://validator.w3.org/feed/">RSS feed Validator</a></li>
+                <li><a href="http://validator.w3.org/unicorn/">Unicorn</a></li>
+                <li><a href="https://validator-suite.w3.org/">Validator Suite</a></li>
+            </ul>
         </section>
       </section>
 


### PR DESCRIPTION
- change repository name for developers landing page
- add more tools
- invite to join the discussion around the landing page on the [developers landing page repository](https://github.com/w3c/developers/)
