### PR TITLE
Fix CSS in editor's draft on gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <script src="https://www.w3.org/Tools/respec/respec-w3c-common" async class="remove"></script>
     <script class="remove">
       var respecConfig = {
-              specStatus:   "webspec"
+              specStatus:   "unofficial"
           ,   shortName:    "modern-tooling"
           ,   editors:      [{ name: "Robin Berjon", url: "http://berjon.com/",
                                company: "W3C", companyURL: "http://w3.org/" }]


### PR DESCRIPTION
Switch `specstatus` from `webspec` to `unofficial`.

cf https://github.com/w3c/respec/issues/643#issuecomment-213451166

Quickest solution to fix #54 (it doesn't look _that_ ugly).
OK to fix it the other way if someone prefers that.
